### PR TITLE
Add T3 Code callout to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,10 +71,7 @@ const links = [
         class="group animate-fade-in-up relative mb-2 flex items-center justify-between py-3 opacity-0"
         style="animation-delay: 0.05s;"
       >
-        <span class="flex flex-col gap-0.5">
-          <span class="text-text">t3 code</span>
-          <span class="text-muted text-xs">the coding agent app</span>
-        </span>
+        <span class="text-text">t3 code</span>
         <span class="text-muted opacity-0 transition-all duration-200 group-hover:translate-x-0.5 group-hover:opacity-100">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,19 +63,19 @@ const links = [
         <p class="text-muted mt-1 text-sm">builds things</p>
       </header>
 
-      <!-- T3 Code callout. Most visitors come here looking for it. -->
+      <!-- T3 Code. Most visitors come here looking for it, so it sits first. -->
       <a
         href="https://t3.codes"
         target="_blank"
         rel="noopener noreferrer"
-        class="group animate-fade-in-up border-accent/40 hover:border-accent mb-8 flex items-center justify-between border-l-2 py-2 pl-4 opacity-0 transition-colors duration-200"
+        class="group animate-fade-in-up relative mb-2 flex items-center justify-between py-3 opacity-0"
         style="animation-delay: 0.05s;"
       >
         <span class="flex flex-col gap-0.5">
-          <span class="text-text text-sm">t3 code</span>
+          <span class="text-text">t3 code</span>
           <span class="text-muted text-xs">the coding agent app</span>
         </span>
-        <span class="text-accent transition-transform duration-200 group-hover:translate-x-0.5">
+        <span class="text-muted opacity-0 transition-all duration-200 group-hover:translate-x-0.5 group-hover:opacity-100">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class="h-3.5 w-3.5"
@@ -86,6 +86,7 @@ const links = [
             <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
           </svg>
         </span>
+        <span class="bg-accent/40 absolute bottom-2 left-0 h-px w-0 transition-all duration-300 ease-out group-hover:w-full" />
       </a>
 
       <!-- Links -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,11 +20,6 @@ const links = [
     external: true,
   },
   {
-    href: "https://t3.codes",
-    label: "t3.code",
-    external: true,
-  },
-  {
     href: "https://youtube.com/@t3dotgg",
     label: "youtube",
     external: true,
@@ -68,6 +63,31 @@ const links = [
         <p class="text-muted mt-1 text-sm">builds things</p>
       </header>
 
+      <!-- T3 Code callout. Most visitors come here looking for it. -->
+      <a
+        href="https://t3.codes"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group animate-fade-in-up border-accent/40 hover:border-accent mb-8 flex items-center justify-between border-l-2 py-2 pl-4 opacity-0 transition-colors duration-200"
+        style="animation-delay: 0.05s;"
+      >
+        <span class="flex flex-col gap-0.5">
+          <span class="text-text text-sm">t3 code</span>
+          <span class="text-muted text-xs">the coding agent app</span>
+        </span>
+        <span class="text-accent transition-transform duration-200 group-hover:translate-x-0.5">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-3.5 w-3.5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+            <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+          </svg>
+        </span>
+      </a>
+
       <!-- Links -->
       <nav class="flex flex-col gap-0">
         {
@@ -77,7 +97,7 @@ const links = [
               target={link.external ? "_blank" : undefined}
               rel={link.external ? "noopener noreferrer" : undefined}
               class="group animate-fade-in-up relative flex items-center justify-between py-3 opacity-0"
-              style={`animation-delay: ${(i + 1) * 0.05}s;`}
+              style={`animation-delay: ${(i + 2) * 0.05}s;`}
             >
               <span class="text-subtle group-hover:text-text transition-colors duration-200">
                 {link.label}
@@ -117,7 +137,7 @@ const links = [
       <!-- Footer -->
       <footer
         class="mt-16 flex items-center gap-x-5 border-t border-white/5 pt-6 text-sm tracking-wider opacity-0 animate-fade-in-up"
-        style={`animation-delay: ${(links.length + 1) * 0.05}s;`}
+        style={`animation-delay: ${(links.length + 2) * 0.05}s;`}
       >
         {
           socialLinks.map((link) => (


### PR DESCRIPTION
A lot of people land on t3.gg looking for T3 Code, and it was buried as one plain entry in the link list.

Now it is a callout right under the header with a short description and a link to t3.codes. The duplicate list entry is gone.

Created with Claude Fable 5.1 in Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dedicated T3 Code callout link to homepage
> - Removes `t3.codes` from the shared links array in [src/pages/index.astro](https://github.com/T3-Content/t3.gg/pull/58/files#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663) and renders it as a separate anchor at the top of the link list
> - The new link opens in a new tab with `noopener`/`noreferrer`, features an external-link icon, hover styles, and a dedicated entrance animation
> - Adjusts the animation delay indices for the remaining links and footer to account for the new first-position element
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcc760f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navigation and footer presentation for the dedicated T3 Code link.
  * Added a simplified link style with a hover-revealed external-link icon and animated underline.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->